### PR TITLE
Fix simulations crashing on MacOS

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,30 @@
+name: lints
+
+on:
+  push:
+    branches: [main, test-me-*]
+    tags:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lints:
+    timeout-minutes: 10
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,10 +44,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install --upgrade setuptools pip
-          pip install .[dev]
-
-      - name: Lint and Type Check
-        run: pre-commit run --all-files
+          pip install .
 
       - name: Run Single Simulation
         run: python run_single.py --total-time 1 --no-gui

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,16 +16,20 @@ jobs:
         include:
         - os: ubuntu-latest
           python: 3.9
-          toxenv: py39
         - os: ubuntu-latest
           python: '3.10'
-          toxenv: py310
         - os: ubuntu-latest
           python: '3.11'
-          toxenv: py311
         - os: ubuntu-latest
           python: '3.12'
-          toxenv: py312
+        - os: macos-14
+          python: 3.9
+        - os: macos-14
+          python: '3.10'
+        - os: macos-14
+          python: '3.11'
+        - os: macos-14
+          python: '3.12'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ A golf green is randomly generated using [Perlin noise](https://en.wikipedia.org
 
 ## Visualize a Simulation
 
-> [!WARNING]
-> We have encountered PyBullet crashes on Apple Silicon.
-> The Globus Compute script in the following section can still be run provided the Globus Compute Endpoint is running on Linux.
-
 We will start with running a single simulation locally to visualize what the simulation looks like.
 This will generate a random terrain and drop a ball at a random position.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 description = "Globus Compute golf simulation demo"
 readme = "README.md"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 dependencies = [
     "globus-compute-endpoint",


### PR DESCRIPTION
Previously, running the simulation on MacOS would raise an error like:
```
b3Printf: b3Warning[examples/SharedMemory/../Importers/ImportURDFDemo/UrdfFindMeshFile.h,21]:

b3Printf: : invalid mesh filename './'

b3Printf: b3Warning[examples/SharedMemory/PhysicsClientSharedMemory.cpp,1357]:

b3Printf: Request createCollisionShape failed
Traceback (most recent call last):
  File "/Users/jgpaul/workspace/green-simulation/run_single.py", line 73, in <module>
    raise SystemExit(main())
                     ^^^^^^
  File "/Users/jgpaul/workspace/green-simulation/run_single.py", line 60, in main
    final_positions = run_simulation(
                      ^^^^^^^^^^^^^^^
  File "/Users/jgpaul/workspace/green-simulation/simulation/simulate.py", line 160, in run_simulation
    collision_shape_id = p.createCollisionShape(
                         ^^^^^^^^^^^^^^^^^^^^^^^
pybullet.error: createCollisionShape failed.
```

I believe this was due to a shared memory buffer overflow. The default terrain mesh in the simulation is pretty large, and MacOS has a small default shared memory size. 

PyBullet has limits for the number of vertices (https://github.com/bulletphysics/bullet3/issues/1965) but I did not get this error reliably. Either way, reducing the terrain size fixes the crashing.

To support larger terrains, the terrains are now chunked and drawn as separate objects. I've also updated the CI to test on ARM MacOS now.